### PR TITLE
BUG: cutadapt base quality cutoff arguments have the wrong type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# biobox unreleased
+# biobox x.x.x (unreleased)
+
+# BUG FIXES
+
+* `cutadapt`: fix nucleotide quality cutoff argument needed their values specified as 
+  strings instead of integers (PR #66).
+
+# biobox 0.1.0
 
 ## BREAKING CHANGES
 

--- a/src/cutadapt/config.vsh.yaml
+++ b/src/cutadapt/config.vsh.yaml
@@ -269,7 +269,7 @@ argument_groups:
           dark cycles appearing as high-quality G bases.
       - name: --quality_cutoff
         alternatives: [-q]
-        type: string
+        type: integer
         description: |
           Trim low-quality bases from 5' and/or 3' ends of each read
           before adapter removal. Applied to both reads if data is
@@ -278,7 +278,7 @@ argument_groups:
           trimmed with the first cutoff, the 3' end with the second.
       - name: --quality_cutoff_r2
         alternatives: [-Q]
-        type: string
+        type: integer
         description: |
           Quality-trimming cutoff for R2. Default: same as for R1
       - name: --quality_base


### PR DESCRIPTION
## Description

<!-- Provide a list of changes made in this PR -->

## Issue ticket number

~Closes #xxxx~

<!-- Replace xxxx with the GitHub issue number -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/base/blob/main/CONTRIBUTING.md)

- [x] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/base/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

<!-- Thank you for your contribution! -->
