### PR TITLE
BUG: permissions of falco output

### DIFF
--- a/src/falco/config.vsh.yaml
+++ b/src/falco/config.vsh.yaml
@@ -194,3 +194,5 @@ engines:
 runners:
   - type: executable
   - type: nextflow
+    config: 
+      script: 'docker.fixOwnership = true'


### PR DESCRIPTION
## Description

Falco, by default, creates the output folder in mode `700`  only. See https://github.com/smithlabcode/falco/blob/3e4f0ad4bee3fa84280c179cc4320bf103c59262/src/falco.cpp#L635

This means that using this component with docker creates files as `root`, which are not usable by the user and causes problems when publishing. There are two solutions for this:

- in the script, use `chmod g+rx,o+rx` on the output folder
- use `docker.fixOwnership = true`. It think this option is preferred because it just changes the owner of the files, not the mode and the fix is only applied when using `docker`.

Why is this not a problem for other components? The behavior occurs when:

1. There is an output argument of type `file`
2. This output will be created by the script of the component and its a directory.
3. The created directory missing read and execute permissions for 'others'.

Most other components create files, for which the permissions are based on the `umask`. The `umask` is by default `022`, so most of the times the files are created with permissions `0644`. This includes read permissions for groups and others.


## Issue ticket number

~Closes #xxxx~

<!-- Replace xxxx with the GitHub issue number -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/base/blob/main/CONTRIBUTING.md)

- [ ] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/base/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

<!-- Thank you for your contribution! -->
