### PR TITLE
FIX: Make output quant file an optional argument

### DIFF
--- a/src/salmon/salmon_quant/config.vsh.yaml
+++ b/src/salmon/salmon_quant/config.vsh.yaml
@@ -24,7 +24,7 @@ argument_groups:
         description: |
           Format string describing the library.
           The library type string consists of three parts: 
-          1. Relative orientation of the reads: This part is only provided if the library is paired-end, THe possible options are
+          1. Relative orientation of the reads: This part is only provided if the library is paired-end, The possible options are
             I = inward
             O = outward
             M = matching
@@ -118,7 +118,7 @@ argument_groups:
         direction: output
         description: |
           Salmon quantification file.
-        required: true
+        required: false
         example: quant.sf
 
   - name: Basic options
@@ -327,7 +327,7 @@ argument_groups:
           If this option is provided, then the selective-alignment results will be written out in SAM-compatible format. By default, output will be directed to stdout, but an alternative file name can be provided instead.
       - name: --mapping_sam
         type: file
-        description: Path to file that should output the selective-alignment results in SAM-compatible format. THis option must be provided while using --write_mappings
+        description: Path to file that should output the selective-alignment results in SAM-compatible format. This option must be provided while using --write_mappings
         required: false
         direction: output
         example: mappings.sam


### PR DESCRIPTION
## Description
The output file `quant.sf` is not generated when `salmon quant` is run with the `--skipQuant` flag, so `quant_results` should be an optional output argument.

## Issue ticket number

Closes #xxxx 

<!-- Replace xxxx with the GitHub issue number -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [ ] Conforms to the [Contributing guidelines](https://github.com/viash-hub/base/blob/main/CONTRIBUTING.md)

- [ ] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/base/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

<!-- Thank you for your contribution! -->
