### PR TITLE
Update `bwa_mem2_mem` `--index` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * `bases2fastq`: Bump version to 2.4.0 (PR #221).
 
+* `bwa_mem2/bwa_mem2_mem`: `--index` now expects the index directory rather than a single index file, so the Nextflow runner stages all index files.
+  Passing a file is still accepted for backward compatibility, with a warning, falling back to its containing directory. (PR #223)
+
 # biobox 0.4.2
 
 ## NEW FUNCTIONALITY

--- a/src/bwa_mem2/bwa_mem2_mem/config.vsh.yaml
+++ b/src/bwa_mem2/bwa_mem2_mem/config.vsh.yaml
@@ -18,9 +18,9 @@ argument_groups:
   arguments: 
   - name: "--index"
     type: file
-    description: BWA index base name (prefix of .0123, .amb, .ann, .bwt.2bit.64, .pac files).
+    description: Directory containing the BWA-MEM2 index files (.0123, .amb, .ann, .bwt.2bit.64, .pac).
     required: true
-    example: reference.fasta
+    example: bwa_index/
   - name: "--reads1"
     type: file
     description: Input FASTQ file with first reads in pair (R1) or single-end reads.

--- a/src/bwa_mem2/bwa_mem2_mem/script.sh
+++ b/src/bwa_mem2/bwa_mem2_mem/script.sh
@@ -60,9 +60,22 @@ cmd_args=(
     ${par_soft_clipping:+-Y}
     ${par_mark_secondary:+-M}
     ${par_insert_size:+-I "$par_insert_size"}
-    
+)
+
+# If --index is a file, use the containing directory with a warning
+if [[ -d "$par_index" ]]; then
+    index_directory="$par_index"
+else
+    index_directory="$(dirname "$par_index")"
+    echo "Warning: --index ('$par_index') is not a directory, using its containing directory ('$index_directory') instead. Pass the index directory itself to --index so all index files are staged correctly under the Nextflow runner." >&2
+fi
+
+# Determine the index prefix from the .0123 index file
+index_prefix="$(basename "$(ls "${index_directory%/}"/*.0123)" .0123)"
+
+cmd_args+=(
     # Index and input files
-    "$par_index"
+    "${index_directory%/}/$index_prefix"
     "$par_reads1"
     ${par_reads2:+"$par_reads2"}
 )

--- a/src/bwa_mem2/bwa_mem2_mem/test.sh
+++ b/src/bwa_mem2/bwa_mem2_mem/test.sh
@@ -58,7 +58,7 @@ log "Starting TEST 1: Single-end BWA MEM alignment"
 
 log "Executing $meta_name with single-end reads..."
 "$meta_executable" \
-  --index "$test_data_dir/index/reference.fasta" \
+  --index "$test_data_dir/index" \
   --reads1 "$test_data_dir/reads_single.fastq" \
   --output "$meta_temp_dir/single_end.sam"
 
@@ -81,7 +81,7 @@ log "Starting TEST 2: Paired-end BWA MEM alignment"
 
 log "Executing $meta_name with paired-end reads..."
 "$meta_executable" \
-  --index "$test_data_dir/index/reference.fasta" \
+  --index "$test_data_dir/index" \
   --reads1 "$test_data_dir/reads_R1.fastq" \
   --reads2 "$test_data_dir/reads_R2.fastq" \
   --output "$meta_temp_dir/paired_end.sam"
@@ -105,7 +105,7 @@ log "Starting TEST 3: BWA MEM with advanced parameters"
 
 log "Executing $meta_name with advanced parameters..."
 "$meta_executable" \
-  --index "$test_data_dir/index/reference.fasta" \
+  --index "$test_data_dir/index" \
   --reads1 "$test_data_dir/reads_single.fastq" \
   --output "$meta_temp_dir/advanced.sam" \
   --min_seed_length 15
@@ -115,5 +115,27 @@ check_file_exists "$meta_temp_dir/advanced.sam" "advanced SAM output"
 check_file_not_empty "$meta_temp_dir/advanced.sam" "advanced SAM output"
 
 log "✅ TEST 3 completed successfully"
+
+# --- Test Case 4: --index is a file  ---
+log "Starting TEST 4: BWA MEM with --index file input"
+
+log "Executing $meta_name with a file passed to --index instead of a directory..."
+legacy_output="$("$meta_executable" \
+  --index "$test_data_dir/index/reference.fasta" \
+  --reads1 "$test_data_dir/reads_single.fastq" \
+  --output "$meta_temp_dir/legacy.sam" 2>&1)"
+
+log "Validating TEST 4 outputs..."
+check_file_exists "$meta_temp_dir/legacy.sam" "SAM output"
+check_file_not_empty "$meta_temp_dir/legacy.sam" "SAM output"
+
+if echo "$legacy_output" | grep -qi "warning.*--index"; then
+  log "✓ Warning emitted for file --index"
+else
+  log_error "Expected a warning about --index not being a directory"
+  exit 1
+fi
+
+log "✅ TEST 4 completed successfully"
 
 print_test_summary "All tests completed successfully"


### PR DESCRIPTION
## Description

<!-- Provide a list of changes made in this PR -->

Update the `--index` argument of the `bwa_mem2_mem` component so that it expects a directory rather than a file. The index contains several file and if only one is provided then the others are not staged when using the Nextflow runner.

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/biobox/blob/main/CONTRIBUTING.md)

- [ ] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/biobox/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

<!-- Thank you for your contribution! -->
