### PR TITLE
Add `snpeff_download` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # biobox x.x.x
 
+## NEW FUNCTIONALITY
+
+* `snpeff`: Added `snpeff_download`: Download a pre-built SnpEff reference genome database (PR #224)
+
 ## MINOR CHANGES
 
 * `bases2fastq`: Bump version to 2.4.0 (PR #221).

--- a/src/_authors/luke_zappia.yaml
+++ b/src/_authors/luke_zappia.yaml
@@ -1,0 +1,11 @@
+name: Luke Zappia
+info:
+  links:
+    email: luke@data-intuitive.com
+    github: lazappi
+    orcid: 0000-0001-7744-8565
+    linkedin: lazappi
+  organizations:
+    - name: Data Intuitive
+      href: https://www.data-intuitive.com
+      role: Data Science Engineer

--- a/src/snpeff/snpeff_download/config.vsh.yaml
+++ b/src/snpeff/snpeff_download/config.vsh.yaml
@@ -1,0 +1,77 @@
+name: snpeff_download
+namespace: snpeff
+description: |
+  Download a pre-built SnpEff reference genome/annotation database.
+keywords: ["annotation", "database", "download", "snp", "variant", "snpeff"]
+
+links:
+  repository: https://github.com/pcingola/SnpEff
+  homepage: https://pcingola.github.io/SnpEff/
+  documentation: https://pcingola.github.io/SnpEff/
+references:
+  doi: 10.3389/fgene.2012.00035
+license: MIT
+requirements:
+  commands: [snpEff]
+authors:
+  - __merge__: /src/_authors/luke_zappia.yaml
+    roles: [author, maintainer]
+argument_groups:
+  - name: Inputs
+    arguments:
+      - name: --genome_version
+        type: string
+        description: Reference genome/database version to download.
+        example: GRCh38.86
+        required: true
+  - name: Outputs
+    arguments:
+      - name: --output
+        type: file
+        description: Directory in which the downloaded database is stored
+        direction: output
+        required: true
+        example: data_dir
+  - name: Generic options
+    arguments:
+      - name: --config
+        alternatives: [-c]
+        type: file
+        description: Specify config file.
+      - name: --config_option
+        type: string
+        description: Override a config file option (name=value).
+      - name: --debug
+        alternatives: [-d]
+        type: boolean_true
+        description: Debug mode (very verbose).
+      - name: --no_log
+        type: boolean_true
+        description: Do not report usage statistics to server.
+      - name: --quiet
+        alternatives: [-q]
+        type: boolean_true
+        description: Quiet mode (do not show any messages or errors).
+      - name: --verbose
+        alternatives: [-v]
+        type: boolean_true
+        description: Verbose mode.
+resources:
+  - type: bash_script
+    path: script.sh
+test_resources:
+  - type: bash_script
+    path: test.sh
+  - path: /src/_utils/test_helpers.sh
+engines:
+  - type: docker
+    image: quay.io/staphb/snpeff:5.4c
+    setup:
+      - type: docker
+        run: |
+          version=$(snpEff -version) && \
+          version_trimmed=$(echo "$version" | awk '{print $1, $2}') && \
+          echo "$version_trimmed" > /var/software_versions.txt
+runners:
+  - type: executable
+  - type: nextflow

--- a/src/snpeff/snpeff_download/help.txt
+++ b/src/snpeff/snpeff_download/help.txt
@@ -1,0 +1,25 @@
+```sh
+snpEff download -h
+```
+```
+snpEff version SnpEff 5.4c (build 2026-02-23 07:25), by Pablo Cingolani
+Usage: snpEff download [options] {snpeff | genome_version}
+```
+
+```sh
+snpEff -h
+```
+```
+Generic options:
+	-c , -config                 : Specify config file
+	-configOption name=value     : Override a config file option
+	-d , -debug                  : Debug mode (very verbose).
+	-dataDir <path>              : Override data_dir parameter from config file.
+	-download                    : Download a SnpEff database, if not available locally. Default: true
+	-nodownload                  : Do not download a SnpEff database, if not available locally.
+	-h , -help                   : Show this help and exit
+	-noLog                       : Do not report usage statistics to server
+	-q , -quiet                  : Quiet mode (do not show any messages or errors)
+	-v , -verbose                : Verbose mode
+	-version                     : Show version number and exit
+```

--- a/src/snpeff/snpeff_download/script.sh
+++ b/src/snpeff/snpeff_download/script.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+## VIASH START
+## VIASH END
+
+[[ "$par_debug" == "false" ]] && unset par_debug
+[[ "$par_no_log" == "false" ]] && unset par_no_log
+[[ "$par_quiet" == "false" ]] && unset par_quiet
+[[ "$par_verbose" == "false" ]] && unset par_verbose
+
+mkdir -p "$par_output"
+
+cmd_args=(
+  ${par_config:+-config "$par_config"}
+  ${par_config_option:+-configOption "$par_config_option"}
+  ${par_debug:+-debug}
+  -dataDir "$par_output"
+  ${par_no_log:+-noLog}
+  ${par_quiet:+-quiet}
+  ${par_verbose:+-verbose}
+)
+
+snpEff download "${cmd_args[@]}" "$par_genome_version"

--- a/src/snpeff/snpeff_download/test.sh
+++ b/src/snpeff/snpeff_download/test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -eo pipefail
+
+## VIASH START
+## VIASH END
+
+source "$meta_resources_dir/test_helpers.sh"
+
+setup_test_env
+
+log "Starting tests for $meta_name"
+
+###########################################################################
+
+log "Starting TEST 1: basic download"
+
+mkdir -p "$meta_temp_dir/test1"
+
+"$meta_executable" \
+  --genome_version AY278488.2 \
+  --output "$meta_temp_dir/test1"
+
+check_dir_exists "$meta_temp_dir/test1/AY278488.2" "downloaded database directory"
+check_file_exists "$meta_temp_dir/test1/AY278488.2/snpEffectPredictor.bin" "downloaded database"
+check_file_not_empty "$meta_temp_dir/test1/AY278488.2/snpEffectPredictor.bin" "downloaded database"
+
+log "✅ TEST 1 completed successfully"
+
+###########################################################################
+
+log "Starting TEST 2: error handling for an unknown genome"
+
+mkdir -p "$meta_temp_dir/test2"
+
+if "$meta_executable" \
+  --genome_version NoSuchGenomeXYZ123 \
+  --output "$meta_temp_dir/test2" 2>/dev/null; then
+  log_error "Component should have failed for an unknown genome version"
+  exit 1
+else
+  log "✓ Component properly failed for an unknown genome version"
+fi
+
+log "✅ TEST 2 completed successfully"
+
+###########################################################################
+
+print_test_summary "All snpeff_download tests completed successfully"


### PR DESCRIPTION
## Description

<!-- Provide a list of changes made in this PR -->

Add a component for the `snpeff download` command so the reference can be downloaded and cached separate to running `snpeff ann`.

Also adds me as an author.

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/biobox/blob/main/CONTRIBUTING.md)

- [ ] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/biobox/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

<!-- Thank you for your contribution! -->
