### PR TITLE
`rseqc_inferexperiment`: update check of RSeQC output for new version

### DIFF
--- a/src/rseqc/rseqc_inferexperiment/test.sh
+++ b/src/rseqc/rseqc_inferexperiment/test.sh
@@ -9,7 +9,6 @@ echo ">>> Prepare test output data"
 
 cat > "$meta_resources_dir/test_data/strandedness.txt" <<EOF
 
-
 This is PairEnd Data
 Fraction of reads failed to determine: 0.0000
 Fraction of reads explained by "1++,1--,2+-,2-+": 1.0000
@@ -17,7 +16,7 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.0000
 EOF
 
 cat > "$meta_resources_dir/test_data/strandedness2.txt" <<EOF
-Unknown Data type
+Unknown data type: Mixture
 EOF
 
 ################################################################################


### PR DESCRIPTION
## Description

### Summary
- CI was failing for `rseqc_inferexperiment` because the expected-output
  fixtures in `test.sh` no longer match the text `infer_experiment.py`
  actually prints in the current RSeQC release pulled at build time.
- Test 1: removed an extra leading blank line from the `strandedness.txt`
  fixture.
- Test 2: updated the `strandedness2.txt` fixture from `Unknown Data type`
  to `Unknown data type: Mixture`, matching the current tool output.

### Why
`config.vsh.yaml` installs RSeQC unpinned (`packages: [ RSeQC ]`), so the
container picked up a newer release whose stdout formatting changed
slightly. The component's own output is unaffected — only the hardcoded
`diff`-based test fixtures were out of date.

## Issue ticket number

Closes #xxxx 

<!-- Replace xxxx with the GitHub issue number -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/biobox/blob/main/CONTRIBUTING.md)

- [x] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/biobox/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

<!-- Thank you for your contribution! -->
